### PR TITLE
Add support for h-align subtle button property

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ The blur-color attribute will control the gradient color of the blurring effect.
 </d2l-more-less>
 ```
 
+#### `h-align`
+
+The `h-align` attribute controls the horizontal alignment of the more-less button, as documented in the [BrightspaceUI/button](https://github.com/BrightspaceUI/button) component.
+
+```html
+<d2l-more-less h-align="text">
+	<!-- content -->
+</d2l-more-less>
+```
+
 ## Developing, Testing and Contributing
 
 After cloning the repo, run `npm install` to install dependencies.

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "polymer.json"
   ],
   "dependencies": {
-    "d2l-button": "^4.2.1",
+    "d2l-button": "^4.4.0",
     "d2l-fastdom-import": "https://github.com/Brightspace/fastdom-import.git#v1.0.2",
     "d2l-icons": "^4.5.1",
     "d2l-localize-behavior": "^1.1.0",

--- a/d2l-more-less.html
+++ b/d2l-more-less.html
@@ -48,6 +48,7 @@ Polymer-based web component to wrap potentially tall piece of content and will a
 			aria-hidden="true"
 			on-tap="__toggleOnClick"
 			text="[[_text]]"
+			h-align="[[halign]]"
 		></d2l-button-subtle>
 	</template>
 </dom-module>
@@ -91,6 +92,13 @@ Polymer-based web component to wrap potentially tall piece of content and will a
 			 * The gradient color of the blurring effect. Must be hex color code.
 			 */
 			blurColor: {
+				type: String
+			},
+			
+			/***
+			 * The h-align property of the more-less button.
+			 */
+			halign: {
 				type: String
 			},
 

--- a/d2l-more-less.html
+++ b/d2l-more-less.html
@@ -48,7 +48,7 @@ Polymer-based web component to wrap potentially tall piece of content and will a
 			aria-hidden="true"
 			on-tap="__toggleOnClick"
 			text="[[_text]]"
-			h-align="[[halign]]"
+			h-align="[[hAlign]]"
 		></d2l-button-subtle>
 	</template>
 </dom-module>
@@ -98,7 +98,7 @@ Polymer-based web component to wrap potentially tall piece of content and will a
 			/***
 			 * The h-align property of the more-less button.
 			 */
-			halign: {
+			hAlign: {
 				type: String
 			},
 


### PR DESCRIPTION
The `h-align` attribute was added to the `BrightspaceUI/button` component in v4.4.0, allowing buttons to be aligned on the text. It would be nice to be able to use this option on the more-less button. 
This involves adding a property to handle passing the attribute into the component as `<d2l-more-less halign="text">`, and bumping the version of the `d2l-button` dependency to `^4.4.0`.