### PR TITLE
fix unit test after replacing MutationObserver with ResizeObserver

### DIFF
--- a/d2l-more-less.html
+++ b/d2l-more-less.html
@@ -108,13 +108,15 @@ Polymer-based web component to wrap potentially tall piece of content and will a
 		},
 
 		__baseHeight: 0,
-		__observer: null,
+		__resizeObserver: null,
+		__mutationObserver: null,
 		__content: null,
 		__contentSlot: null,
 		__autoExpanded: false,
 		__shift: false,
 		__transitionAdded: false,
 		__bound_reactToChanges: null,
+		__bound_reactToMutationChanges: null,
 
 		attached: function moreLessAttached() {
 			this.__content = this.$$('.more-less-content');
@@ -126,9 +128,13 @@ Polymer-based web component to wrap potentially tall piece of content and will a
 		},
 
 		detached: function moreLessDetached() {
-			if (this.__observer) {
-				this.__observer.disconnect();
-				this.__observer = null;
+			if (this.__resizeObserver) {
+				this.__resizeObserver.disconnect();
+				this.__resizeObserver = null;
+			}
+			if (this.__mutationObserver) {
+				this.__mutationObserver.disconnect();
+				this.__mutationObserver = null;
 			}
 
 			this.__content.removeEventListener('load', this.__bound_reactToChanges, true);
@@ -318,7 +324,18 @@ Polymer-based web component to wrap potentially tall piece of content and will a
 			this.__content.style.height = this.height;
 		},
 
-		__reactToChanges: function moreLessReactToChanges(entries) {
+		__reactToMutationChanges: function moreLessReactToMutationChanges(mutations) {
+			if (mutations
+				&& Array.isArray(mutations)
+				&& mutations.every(this.__isOwnMutation.bind(this))
+			) {
+				return;
+			}
+
+			this.__reactToChanges();
+		},
+
+		__reactToChanges: function moreLessReactToChanges() {
 			if (!this.__transitionAdded) {
 				fastdom.mutate(this.__reactToChanges_setupTransition, this);
 			} else {
@@ -336,15 +353,24 @@ Polymer-based web component to wrap potentially tall piece of content and will a
 			fastdom.measure(this.__adjustToContent, this);
 		},
 
+		__isOwnMutation: function moreLessIsOwnMutation(mutation) {
+			return mutation.target === this.__content
+				&& (mutation.type === 'style' || mutation.type === 'attributes');
+		},
+
 		__startObserving: function moreLessStartObserving() {
 			this.__bound_reactToChanges = this.__bound_reactToChanges || this.__reactToChanges.bind(this);
-			this.__observer = this.__observer || new ResizeObserver(this.__bound_reactToChanges);
-			this.__observer.disconnect();
+			this.__bound_reactToMutationChanges = this.__bound_reactToMutationChanges || this.__reactToMutationChanges.bind(this);
+			this.__resizeObserver = this.__resizeObserver || new ResizeObserver(this.__bound_reactToChanges);
+			this.__resizeObserver.disconnect();
+			this.__mutationObserver = this.__mutationObserver || new MutationObserver(this.__bound_reactToMutationChanges);
+			this.__mutationObserver.disconnect();
 
 			if (this.__contentSlot) {
 				var children = D2L.Dom.getComposedChildren(this.__contentSlot);
 				for (var i = 0; i < children.length; ++i) {
-					this.__observer.observe(children[i], {
+					this.__resizeObserver.observe(children[i]);
+					this.__mutationObserver.observe(children[i], {
 						childList: true,
 						subtree: true,
 						characterData: true,
@@ -352,7 +378,8 @@ Polymer-based web component to wrap potentially tall piece of content and will a
 					});
 				}
 			}
-			this.__observer.observe(this.__content, {
+			this.__resizeObserver.observe(this.__content);
+			this.__mutationObserver.observe(this.__content, {
 				childList: true,
 				subtree: true,
 				characterData: true,

--- a/d2l-more-less.html
+++ b/d2l-more-less.html
@@ -139,6 +139,8 @@ Polymer-based web component to wrap potentially tall piece of content and will a
 
 			this.__content.removeEventListener('load', this.__bound_reactToChanges, true);
 			this.__bound_reactToChanges = null;
+			this.__bound_reactToMutationChanges = null;
+
 			if (this.__contentSlot) {
 				this.unlisten(this.__contentSlot, 'slotchange', '__reactToChanges');
 				this.unlisten(this.__contentSlot, 'slotchange', '__startObserving');

--- a/d2l-more-less.html
+++ b/d2l-more-less.html
@@ -318,14 +318,7 @@ Polymer-based web component to wrap potentially tall piece of content and will a
 			this.__content.style.height = this.height;
 		},
 
-		__reactToChanges: function moreLessReactToChanges(mutations) {
-			if (mutations
-				&& Array.isArray(mutations)
-				&& mutations.every(this.__isOwnMutation.bind(this))
-			) {
-				return;
-			}
-
+		__reactToChanges: function moreLessReactToChanges(entries) {
 			if (!this.__transitionAdded) {
 				fastdom.mutate(this.__reactToChanges_setupTransition, this);
 			} else {
@@ -341,11 +334,6 @@ Polymer-based web component to wrap potentially tall piece of content and will a
 			this.__addTransition();
 
 			fastdom.measure(this.__adjustToContent, this);
-		},
-
-		__isOwnMutation: function moreLessIsOwnMutation(mutation) {
-			return mutation.target === this.__content
-				&& (mutation.type === 'style' || mutation.type === 'attributes');
 		},
 
 		__startObserving: function moreLessStartObserving() {

--- a/test/d2l-more-less.html
+++ b/test/d2l-more-less.html
@@ -77,7 +77,7 @@
 							var previousContentHeight = content.scrollHeight;
 							expect(elem.offsetHeight).to.be.above(content.scrollHeight);
 							var p = document.getElementById('clone-target');
-							p.parentNode.appendChild(p.cloneNode(true));
+							content.appendChild(p.cloneNode(true));
 
 							waitForInitialization(function() {
 								expect(content.scrollHeight).to.be.above(previousContentHeight);

--- a/test/d2l-more-less.html
+++ b/test/d2l-more-less.html
@@ -77,7 +77,7 @@
 							var previousContentHeight = content.scrollHeight;
 							expect(elem.offsetHeight).to.be.above(content.scrollHeight);
 							var p = document.getElementById('clone-target');
-							content.appendChild(p.cloneNode(true));
+							p.parentNode.appendChild(p.cloneNode(true));
 
 							waitForInitialization(function() {
 								expect(content.scrollHeight).to.be.above(previousContentHeight);


### PR DESCRIPTION
No longer need isOwnMutation because callback is triggered only on resize. Unit test was failing because appending child directly to content instead of p.parentNode was not triggering slotchange event.