### PR TITLE
Use a web component compatible polyfill for ResizeObserver

### DIFF
--- a/d2l-more-less.js
+++ b/d2l-more-less.js
@@ -3,7 +3,7 @@ import 'd2l-button/d2l-button-subtle.js';
 import 'fastdom/fastdom.js';
 import 'd2l-icons/tier1-icons.js';
 import 'd2l-polymer-behaviors/d2l-dom.js';
-import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
+import { ResizeObserver } from 'd2l-resize-aware/resize-observer-module.js';
 import './localize-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
     "@polymer/polymer": "^3.0.0",
-    "resize-observer-polyfill": "^1.5.0"
+    "d2l-resize-aware": "git://github.com/BrightspaceUI/resize-aware.git#semver:^1"
   }
 }


### PR DESCRIPTION
The ResizeObserver polyfill being used here has [an issue](https://github.com/que-etc/resize-observer-polyfill/issues/51) in that it fails to respond to resizes caused by changes in the shadow DOM of webcomponents.

This PR switches to using a polyfill that correctly handles web components.